### PR TITLE
Add CreateInterest endpoint to InterestController

### DIFF
--- a/Controllers/InterestController.cs
+++ b/Controllers/InterestController.cs
@@ -26,7 +26,13 @@ namespace Labb3_API.Controllers
             return Ok(interests);
         }
         /*---------------------------------------------------------------------------*/
-
-       
+        [HttpPost(Name = "Add a new Interest")]
+        public async Task<ActionResult<Interest>> CreateInterest([FromQuery]Interest interest)
+        {
+            await _interestRepository.AddAsync(interest);
+            await _interestRepository.SaveAsync();
+            return CreatedAtAction(nameof(GetAllInterests), new { id = interest.Id }, interest);
+        }
+        /*---------------------------------------------------------------------------*/
     }
 }


### PR DESCRIPTION
This commit introduces a new HTTP POST endpoint in the `InterestController` class. The `CreateInterest` method allows clients to create a new interest by accepting an `Interest` object from the query parameters. It adds the interest to the repository, saves the changes, and returns a `201 Created` response with the details of the newly created interest.